### PR TITLE
OIDC endpoint discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ dirs = { version = "5.0.1", default-features = false }
 http = { version = "1.1.0", default-features = false }
 http-serde = { version = "2.1.1", default-features = false }
 md-5 = { version = "0.10.6", default-features = false }
-oauth2 = { version = "4.4.2", default-features = false, features = ["reqwest", "rustls-tls"] }
+openidconnect = { version = "3.5", default-features = false, features = ["reqwest", "rustls-tls"] }
 qrcode = { version = "0.14.1", default-features = false }
 reqwest = { version = "0.11.0", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde = { version = "1.0.204", default-features = false }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,14 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::{Context, Result};
-use oauth2::reqwest::http_client;
-use oauth2::{
-    basic::BasicClient, AuthType, AuthUrl, ClientId, DeviceAuthorizationUrl, Scope,
-    StandardDeviceAuthorizationResponse, TokenUrl,
+use openidconnect::core::{
+    CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod,
+    CoreDeviceAuthorizationResponse, CoreGrantType, CoreJsonWebKey, CoreJsonWebKeyType,
+    CoreJsonWebKeyUse, CoreJweContentEncryptionAlgorithm, CoreJweKeyManagementAlgorithm,
+    CoreJwsSigningAlgorithm, CoreResponseMode, CoreResponseType, CoreSubjectIdentifierType,
 };
-use oauth2::{AccessToken, TokenResponse as _};
+use openidconnect::reqwest::http_client;
+use openidconnect::{
+    AccessToken, AdditionalProviderMetadata, AuthType, ClientId, DeviceAuthorizationUrl, IssuerUrl,
+    OAuth2TokenResponse as _, ProviderMetadata, Scope,
+};
 use qrcode::{render::unicode, QrCode};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::{cache, config};
@@ -19,28 +24,55 @@ struct Token {
     token: String,
 }
 
+// Obtain the device_authorization_url from the OIDC metadata provider.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct DeviceEndpointProviderMetadata {
+    device_authorization_endpoint: DeviceAuthorizationUrl,
+}
+impl AdditionalProviderMetadata for DeviceEndpointProviderMetadata {}
+type DeviceProviderMetadata = ProviderMetadata<
+    DeviceEndpointProviderMetadata,
+    CoreAuthDisplay,
+    CoreClientAuthMethod,
+    CoreClaimName,
+    CoreClaimType,
+    CoreGrantType,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJweKeyManagementAlgorithm,
+    CoreJwsSigningAlgorithm,
+    CoreJsonWebKeyType,
+    CoreJsonWebKeyUse,
+    CoreJsonWebKey,
+    CoreResponseMode,
+    CoreResponseType,
+    CoreSubjectIdentifierType,
+>;
+
 /// Given an OAuth `client_id` and URL, authenticate with the device code workflow
 pub fn get_keycloak_token(
     client_id: &String,
     issuer_url: &Url,
     open_webpage: bool,
 ) -> Result<AccessToken> {
+    let issuer_url = IssuerUrl::from_url(issuer_url.clone());
     let client_id = ClientId::new(client_id.to_string());
     let client_secret = None;
 
-    // TODO get these from https://{keycloak}/realms/{realm}/.well-known/openid-configuration
-    let auth_url = AuthUrl::from_url(issuer_url.join("protocol/openid-connect/auth/device")?);
-    let token_url = TokenUrl::from_url(issuer_url.join("protocol/openid-connect/token")?);
-    let device_auth_url =
-        DeviceAuthorizationUrl::from_url(issuer_url.join("protocol/openid-connect/auth/device")?);
+    let provider_metadata = DeviceProviderMetadata::discover(&issuer_url, http_client)
+        .context("Cannot discover OIDC metadata.")?;
 
-    // Set up the config for the Keycloak OAuth2 process.
-    let device_client = BasicClient::new(client_id, client_secret, auth_url, Some(token_url))
-        .set_device_authorization_url(device_auth_url)
-        .set_auth_type(AuthType::RequestBody);
+    let device_auth_url = provider_metadata
+        .additional_metadata()
+        .device_authorization_endpoint
+        .clone();
+
+    let device_client =
+        CoreClient::from_provider_metadata(provider_metadata, client_id, client_secret)
+            .set_device_authorization_uri(device_auth_url)
+            .set_auth_type(AuthType::RequestBody);
 
     // Request the set of codes from the Device Authorization endpoint.
-    let details: StandardDeviceAuthorizationResponse = device_client
+    let details: CoreDeviceAuthorizationResponse = device_client
         .exchange_device_code()
         .context("Cound not exchange device code.")?
         .add_scope(Scope::new("openid".to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,7 +385,7 @@ fn main() -> Result<()> {
 }
 
 /// Waldur uses old MD5 fingerprints so we must convert to that format
-pub fn fingerprint_md5(key: &ssh_key::PrivateKey) -> Result<String> {
+fn fingerprint_md5(key: &ssh_key::PrivateKey) -> Result<String> {
     let mut sh = md5::Md5::default();
     sh.update(key.public_key().to_bytes()?);
     let md5: Vec<String> = sh.finalize().iter().map(|n| format!("{n:02x}")).collect();


### PR DESCRIPTION
OIDC endpoints are best set via the [discovery mechanism](https://openid.net/specs/openid-connect-discovery-1_0.html) rather than hard-coding paths. This is not supported by `oauth2`, but a smaller library on top by the same author, [`openidconnect`](https://crates.io/crates/openidconnect) does support it. Currently it's quite verbose to code this due to the API, but both `oauth2` and `openidconenct` are due a new major release quite soon, so will return to this after that is out.