### PR TITLE
Support the new Conch CA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,6 @@ dependencies = [
  "dirs",
  "http 1.1.0",
  "http-serde",
- "md-5",
  "mockito",
  "oauth2",
  "qrcode",
@@ -1097,16 +1096,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
-]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "4.5", default-features = false, features = ["derive", "color
 dirs = { version = "5.0", default-features = false }
 http = { version = "1.1", default-features = false }
 http-serde = { version = "2.1", default-features = false }
-md-5 = { version = "0.10", default-features = false }
 oauth2 = { version = "4.4", default-features = false, features = ["reqwest", "rustls-tls"] }
 qrcode = { version = "0.14", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -51,6 +51,13 @@ pub fn read_file<P: AsRef<std::path::Path>>(file: P) -> Result<String> {
     Ok(std::fs::read_to_string(path)?)
 }
 
+/// Delete a file from the cache
+pub fn delete_file<P: AsRef<std::path::Path>>(file: P) -> Result<()> {
+    let cache_dir = cache_dir()?;
+    let path = cache_dir.join(file);
+    std::fs::remove_file(path).context("Could not delete cache file.")
+}
+
 /// Delete the entire cache directory
 pub fn delete_all() -> Result<()> {
     std::fs::remove_dir_all(cache_dir()?).context("Could not delete cache directory.")

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,15 +9,12 @@ pub struct Config {
     /// Should the browser be automatically opened when authenticating
     #[serde(default = "Config::default_open_browser")]
     pub open_browser: bool,
-    /// Should the QR code be shown then authenticating
+    /// Should the QR code be shown when authenticating
     #[serde(default = "Config::default_show_qr")]
     pub show_qr: bool,
-    /// The URL of the KeyCloak instance
-    #[serde(default = "Config::default_keycloak_url")]
-    pub keycloak_url: Url,
-    /// The URL of the Waldur API server
-    #[serde(default = "Config::default_waldur_api_url")]
-    pub waldur_api_url: Url,
+    /// The URL of the CA server
+    #[serde(default = "Config::default_ca_url")]
+    pub ca_url: Url,
     /// The client ID in KeyCloak
     #[serde(default = "Config::default_client_id")]
     pub client_id: String,
@@ -30,23 +27,17 @@ pub struct Config {
 }
 
 impl Config {
-    fn default_keycloak_url() -> Url {
-        #[allow(clippy::expect_used)]
-        "https://keycloak.isambard.ac.uk/realms/isambard/"
-            .parse()
-            .expect("Default KeyCloak path does not parse")
-    }
     fn default_open_browser() -> bool {
         true
     }
     fn default_show_qr() -> bool {
         true
     }
-    fn default_waldur_api_url() -> Url {
+    fn default_ca_url() -> Url {
         #[allow(clippy::expect_used)]
-        "https://portal-api.isambard.ac.uk/"
+        "https://ca.isambard.ac.uk/"
             .parse()
-            .expect("Default Waldur API path does not parse")
+            .expect("Default CA URL does not parse")
     }
     fn default_client_id() -> String {
         "clifton".to_string()


### PR DESCRIPTION
This ports Clifton to use the new Conch CA by default.

Since Conch uses the new format for returning the certificate information, the way in which the SSH config file is written will change slightly. This allows multiple infrastructures to be supported as well as jump hosts to be optional.

Fixes #21