### PR TITLE
Add ServerAliveInterval to keep ssh from dying

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # Clifton - an SSH connection manager
 
-Clifton is used to retrieve SSH certificates for acessing AI Research Resources.
+Clifton is used to retrieve SSH certificates for accessing AI Research Resources.
 
 There are two main commands in `clifton` that you will need, `auth` and `ssh-config`.
 

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -233,6 +233,7 @@ impl CertificateConfigCache {
                                 \tHostname {}\n\
                                 \tIdentityFile \"{1}\"\n\
                                 \tCertificateFile \"{1}-cert.pub\"\n\
+                                \tServerAliveInterval 60\n\
                             \n",
                         proxy_jump,
                         self.identity.display(),
@@ -244,6 +245,7 @@ impl CertificateConfigCache {
                                 \tIdentityFile \"{2}\"\n\
                                 \tCertificateFile \"{2}-cert.pub\"\n\
                                 \tAddKeysToAgent yes\n\
+                                \tServerAliveInterval 60\n\
                             \n",
                         &c.alias,
                         &c.hostname,
@@ -257,6 +259,7 @@ impl CertificateConfigCache {
                                 \tIdentityFile \"{2}\"\n\
                                 \tCertificateFile \"{2}-cert.pub\"\n\
                                 \tAddKeysToAgent yes\n\
+                                \tServerAliveInterval 60\n\
                             \n",
                         &c.alias,
                         &c.hostname,


### PR DESCRIPTION
I'm not sure on whose end the problem lies, but I've noticed my SSH connections become unresponsive/die without `ServerAliveInterval`.