### PR TITLE
enable rustls-native-certs for reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1751,6 +1752,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1869,6 +1871,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1925,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +1951,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http = { version = "1.3", default-features = false }
 http-serde = { version = "2.1", default-features = false }
 oauth2 = { version = "5.0", default-features = false, features = ["rustls-tls", "reqwest-blocking"] }
 qrcode = { version = "0.14", default-features = false }
-reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "blocking", "rustls-tls-native-roots"] }
 serde = { version = "1.0", default-features = false }
 semver = { version = "1.0", default-features = false, features = ["serde", "std"] }
 serde_json = { version = "1.0", default-features = false }


### PR DESCRIPTION
# What?

I've found that this patch resolves issues with Clifton, on my corp machine which runs zscaler:

```
$ clifton auth
Error: Could not get CA OIDC details.

Caused by:
    0: error sending request for url (https://ca.isambard.ac.uk/oidc)
    1: client error (Connect)
    2: invalid peer certificate: UnknownIssuer
```

```
commit 3a44ec896514c5c4b2642378f797c99e02b1f7e9
Author: Nicholas Sielicki <nick.sielicki@hpe.com>
Date:   Fri Nov 21 10:49:16 2025 -0600

    deps: reqwest: enable rustls-tls-native-roots flag

    Some corporate networks have started MITM'ing all traffic through
    products like Zscaler. This works like any MITM attack -- it terminates
    TLS, inspects the unencrypted traffic, and presents a new TLS session to
    the downstream application. TLS is designed to prevent this, so a phony
    root certificate authority must be installed system-wide such that
    downstream applications will accept the fake TLS session.

    rustls (and by extension, reqwest) defaults to using webpki-roots, which
    obviously will not contain the phony local certificate needed for local
    applications to accept the MITM'd traffic. This causes TLS errors when
    attempting to use clifton on impacted machines.

    > $ clifton auth
    > Error: Could not get CA OIDC details.
    >
    > Caused by:
    >     0: error sending request for url (https://ca.isambard.ac.uk/oidc)
    >     1: client error (Connect)
    >     2: invalid peer certificate: UnknownIssuer

    Use the rustls-tls-native-roots feature flag on reqwest, to pull in
    rustls-native-certs and consult the system CA roots instead.

    Signed-off-by: Nicholas Sielicki <nick.sielicki@hpe.com>
```

See https://geekingfrog.com/blog/post/corporate-man-in-the-middle for more details

# Testing

Built and run locally, under wsl.

# Considerations

I don't believe that this will break any of the static builds that are distributed, but it's worth calling out that consulting the system root certificate store relies on using `-sys` crates and this might impact portability.

If this is a problem, I can try to rework this patch as a non-default feature flag for clifton, so that this remains available for people who want to rebuild from scratch without impacting the default build.