### PR TITLE
Add checks for security of GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Matt Williams <matt.williams@bristol.ac.uk>
+# SPDX-License-Identifier: CC0-1.0
+
+name: Check GitHub Actions
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  actionlint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Download actionlint
+        run: |
+          wget "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz"
+          echo "${HASH}" "actionlint_${VERSION}_linux_amd64.tar.gz" | sha256sum --check
+          tar xvf "actionlint_${VERSION}_linux_amd64.tar.gz"
+        env:
+          VERSION: "1.7.12"
+          HASH: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+      - name: Run actionlint
+        run: ./actionlint -color
+  zizmor:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -72,37 +76,41 @@ jobs:
             asset-name: clifton-freebsd-x86_64
             compress-binary: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || '' }}
           fetch-depth: 0  # This is needed so that git-describe works properly to set the version
+          persist-credentials: false
       - name: install MUSL
         if: contains(matrix.target, 'musl')
         run: sudo apt install musl-tools
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          target: ${{ matrix.target }}
+        run: rustup toolchain install stable --target="${{ matrix.target }}"
       - name: Install cross
-        uses: taiki-e/install-action@cross
+        uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
+        with:
+          tool: cross
         if: matrix.cross
       - name: Build
-        run: cargo build --target=${{ matrix.target }} --release
+        run: cargo build --target="${{ matrix.target }}" --release
         if: ${{ ! matrix.cross }}
       - name: Build
-        run: cross build --target=${{ matrix.target }} --release
+        run: cross build --target="${{ matrix.target }}" --release
         if: matrix.cross
       - name: Rename assets
-        run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.asset-name }}
+        run: cp "target/${{ matrix.target }}/release/${{ matrix.output }}" "${{ matrix.asset-name }}"
       - name: Compress output
         run: |
-          upx_ver="5.1.1"
-          wget "https://github.com/upx/upx/releases/download/v${upx_ver}/upx-${upx_ver}-amd64_linux.tar.xz"
-          tar xvf "upx-${upx_ver}-amd64_linux.tar.xz"
-          upx-${upx_ver}-amd64_linux/upx ${{ matrix.asset-name }}
+          wget "https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz"
+          echo "${UPX_HASH}" "upx-${UPX_VERSION}-amd64_linux.tar.xz" | sha256sum --check
+          tar xvf "upx-${UPX_VERSION}-amd64_linux.tar.xz"
+          "upx-${UPX_VERSION}-amd64_linux/upx" "${{ matrix.asset-name }}"
+        env:
+          UPX_VERSION: "5.1.1"
+          UPX_HASH: "1ff660454227861e00772f743f66b900072116b9dc24f6ee28b97cce88a7828a"
         if: ${{ matrix.compress-binary }}
       - name: Store build artefacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           path: ${{ matrix.asset-name }}
           archive: false
@@ -110,13 +118,13 @@ jobs:
         if: endswith(matrix.asset-name, '.exe')
         id: exe-zip
         run: |
-          ZIP_FILE="$(basename ${{ matrix.asset-name }} .exe).zip"
+          ZIP_FILE="$(basename "${{ matrix.asset-name }}" .exe).zip"
           mv "${{ matrix.asset-name }}" "clifton.exe"
           zip "${ZIP_FILE}" "clifton.exe"
           echo "ZIP_FILE=${ZIP_FILE}" >> "${GITHUB_OUTPUT}"
       - name: Store zip artefacts
         if: steps.exe-zip.outcome == 'success'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           path: ${{ steps.exe-zip.outputs.ZIP_FILE }}
           archive: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,10 @@ on:
         type: string
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,9 +26,10 @@ jobs:
     name: License REUSE spec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Install reuse
         run: |
           python -m venv ~/venv
@@ -35,9 +40,10 @@ jobs:
     name: Changelog format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
+          persist-credentials: false
       - name: Install kacl
         run: |
           python -m venv ~/venv
@@ -76,33 +82,32 @@ jobs:
             os: "ubuntu-latest"
             cross: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0  # This is needed so that git-describe works properly to set the version
+          persist-credentials: false
       - name: install MUSL
         if: contains(matrix.target, 'musl')
         run: sudo apt install musl-tools
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-          targets: ${{ matrix.target }}
-          components: clippy, rustfmt
-      - uses: Swatinem/rust-cache@v2
+        run: rustup toolchain install stable --target="${{ matrix.target }}" --component="clippy,rustfmt"
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cross
-        uses: taiki-e/install-action@cross
+        uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
+        with:
+          tool: cross
         if: matrix.cross
       - name: Formatting
         run: cargo fmt --check
       - name: Linting
         run: cargo clippy
       - name: Build
-        run: cargo build --target=${{ matrix.target }}
+        run: cargo build --target="${{ matrix.target }}"
         if: ${{ ! matrix.cross }}
       - name: Build
-        run: cross build --target=${{ matrix.target }}
+        run: cross build --target="${{ matrix.target }}"
         if: matrix.cross
       - name: Test
-        run: cargo test --target=${{ matrix.target }}
+        run: cargo test --target="${{ matrix.target }}"
         if: ${{ ! matrix.cross }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,12 @@ jobs:
         shell: bash
         if: ${{ !contains(fromJSON('["major", "minor", "patch"]'), inputs.version) }}
         run: |
-          if ! [[ '${{ inputs.version }}' =~ [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then
-            echo "::error::Verseion string must be a valid semver string"
+          if ! [[ "${INPUTS_VERSION}" =~ [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ ]]; then
+            echo "::error::Version string must be a valid semver string"
             exit 1
           fi
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
   check:
     name: Check
@@ -50,61 +52,68 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write  # Needed to write the tag to the repo
     outputs:
       ref: "${{ steps.get_version.outputs.version }}"
       changelog: "${{ steps.changelog.outputs.changelog }}"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.ref }}  # Use ref here since we must commit on a branch
           ssh-key: ${{secrets.DEPLOY_KEY}}
+          persist-credentials: true
       - name: Install kacl
         run: |
           python -m venv ~/venv
           ~/venv/bin/pip install python-kacl
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          target: ${{ matrix.target }}
+        run: rustup toolchain install stable
       - name: Install cargo-edit tool
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
         with:
           tool: cargo-edit
       - name: Update version string
         run: |
-          echo Version input is '${{ inputs.version }}'
-          if [ '${{ contains(fromJSON('["major", "minor", "patch"]'), inputs.version) }}' = 'true' ]; then
+          echo Version input is "${INPUTS_VERSION}"
+          if [ "${VERSION_IS_BUMP}" = 'true' ]; then
             echo 'Setting based on update spec'
-            cargo set-version --bump ${{ inputs.version }}
-          elif [ -n '${{ inputs.version }}' ]; then
+            cargo set-version --bump "${INPUTS_VERSION}"
+          elif [ -n "${INPUTS_VERSION}" ]; then
             echo 'Updating based on explicit version'
-            cargo set-version ${{ inputs.version }}
+            cargo set-version "${INPUTS_VERSION}"
           fi
           git add Cargo.toml Cargo.lock
+        env:
+          VERSION_IS_BUMP: ${{ contains(fromJSON('["major", "minor", "patch"]'), inputs.version) }}
+          INPUTS_VERSION: ${{ inputs.version }}
       - name: Save the version
         id: get_version
         run: echo version="$(cargo metadata --format-version 1 --no-deps | jq --raw-output '.packages[0].version')" >> "${GITHUB_OUTPUT}"
       - name: Update version in changelog
         id: changelog
         run: |
-          ~/venv/bin/kacl-cli release --allow-dirty --no-commit --modify --link "https://github.com/${{ github.repository }}/releases/tag/${{ steps.get_version.outputs.version }}" "${{ steps.get_version.outputs.version }}"
+          ~/venv/bin/kacl-cli release --allow-dirty --no-commit --modify --link "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${STEPS_GET_VERSION_OUTPUTS_VERSION}" "${STEPS_GET_VERSION_OUTPUTS_VERSION}"
           git add CHANGELOG.md
           {
             echo 'changelog<<EOF'
-            ~/venv/bin/kacl-cli get "${{ steps.get_version.outputs.version }}" | tail -n+2
+            ~/venv/bin/kacl-cli get "${STEPS_GET_VERSION_OUTPUTS_VERSION}" | tail -n+2
             echo EOF
           }  >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STEPS_GET_VERSION_OUTPUTS_VERSION: ${{ steps.get_version.outputs.version }}
       - name: Tag release
         run: |
           git config --global user.name "GitHub Action"
           git config --global user.email "action@github.com"
-          git commit -m "Release ${{ steps.get_version.outputs.version }}"
-          git tag -a -m "Release ${{ steps.get_version.outputs.version }}" "${{ steps.get_version.outputs.version }}"
+          git commit -m "Release ${STEPS_GET_VERSION_OUTPUTS_VERSION}"
+          git tag -a -m "Release ${STEPS_GET_VERSION_OUTPUTS_VERSION}" "${STEPS_GET_VERSION_OUTPUTS_VERSION}"
           git push --atomic --tags origin HEAD
+        env:
+          STEPS_GET_VERSION_OUTPUTS_VERSION: ${{ steps.get_version.outputs.version }}
 
   build-release:
-    name: "Build release (${{ matrix.target }})"
+    name: "Build release"
     needs: tag-release
     uses: ./.github/workflows/build.yml
     with:
@@ -118,31 +127,34 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      attestations: write
-      id-token: write
+      attestations: write  # Needed to persist the attestations
+      id-token: write  # Needed to mint the OIDC token necessary to request a Sigstore signing certificate
+      artifact-metadata: write  # Needed to create the artifact storage record
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup toolchain install stable
       - name: Install cargo-sbom
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7769b73c2ec98c38dfcf2e18c83cfd4880c038c1 # v2.75.27
         with:
           tool: cargo-sbom
       - name: Generate SBOM
         run: cargo sbom --output-format=spdx_json_2_3 > sbom.spdx.json
       - name: Fetch release artefacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: clifton-*
           merge-multiple: true
           skip-decompress: true
       - name: Attest SBOM
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-path: clifton-*
           sbom-path: sbom.spdx.json
       - name: Store SBOM
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom.spdx.json
           path: sbom.spdx.json
@@ -152,31 +164,33 @@ jobs:
     needs: [build-release, tag-release, attest]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pages: write
-      id-token: write
+      contents: write  # Needed to write the release information
+      pages: write  # Needed to write the pages below. Last used in 0.2.0. To be removed in the future.
+      id-token: write  # Needed to create a token to write to Pages. Also to be removed at some point.
     steps:
       - name: Fetch release artefacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: clifton-*
           merge-multiple: true
           skip-decompress: true
       - name: Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.tag-release.outputs.ref }}
-          files: clifton-*
-          body: ${{ needs.tag-release.outputs.changelog }}
+        run: gh release create "${TAG_NAME}" clifton-* --notes "${NOTES}" --repo "${GITHUB_REPOSITORY}"
+        env:
+          TAG_NAME: ${{ needs.tag-release.outputs.ref }}
+          NOTES: ${{ needs.tag-release.outputs.changelog }}
+          GH_TOKEN: ${{ github.token }}
       # This was last used in version 0.2.0. It should be removed at some point.
       - name: Make release data file
         run: |
           mkdir site
-          echo '[{"version" : "'${{ needs.tag-release.outputs.ref }}'", "date" : "'$(date --iso-8601)'"}]' > site/releases
+          echo '[{"version" : "'"${NEEDS_TAG_RELEASE_OUTPUTS_REF}"'", "date" : "'"$(date --iso-8601)"'"}]' > site/releases
+        env:
+          NEEDS_TAG_RELEASE_OUTPUTS_REF: ${{ needs.tag-release.outputs.ref }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
This uses [zimzmor](https://zizmor.sh/) and [actionlint](https://github.com/rhysd/actionlint) to check for known issues with vulnerable Actions patterns and reduces the attack surface for supply chain issues.