### PR TITLE
Improve basic help text

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -411,13 +411,26 @@ fn main() -> Result<()> {
         Some(Commands::Config) => {
             println!("{}", &config_file_path.display());
         }
-        None => Args::command().print_help()?,
+        None => print_getting_started(),
     }
 
     // TODO Generate known_hosts line for host certificate
     // TODO Write known_hosts line
 
     Ok(())
+}
+
+// Getting started message
+fn print_getting_started() {
+    let cmd = Args::command();
+    println!("\nTo use clifton, run `clifton auth` and follow your browser!\n");
+    println!("Usage:");
+    for sub in cmd.get_subcommands() {
+        if !sub.is_hide_set() {
+            println!("  clifton {}", sub.get_name());
+        }
+    }
+    println!("\nRun `clifton help` for detailed information on the commands.");
 }
 
 /// Get a signed certificate from CA

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,14 +423,23 @@ fn main() -> Result<()> {
 // Getting started message
 fn print_getting_started() {
     let cmd = Args::command();
-    println!("\nTo use clifton, run `clifton auth` and follow your browser!\n");
-    println!("Usage:");
+
+    println!("An SSH connection manager\n");
+    println!("To get started, run:\n");
+    println!("  clifton auth\n");
+    println!("This will open a browser window so you can log in.\n");
+    println!(
+        "In order to connect via SSH to the remote server, Clifton can generate SSH config. To get Clifton to to write this config for you, run:\n"
+    );
+    println!("  clifton ssh-config write\n");
+    println!("This will print out the SSH aliases you can use.\n");
+    println!("Available commands:");
     for sub in cmd.get_subcommands() {
         if !sub.is_hide_set() {
             println!("  clifton {}", sub.get_name());
         }
     }
-    println!("\nRun `clifton help` for detailed information on the commands.");
+    println!("\nRun `clifton help` for more details.");
 }
 
 /// Get a signed certificate from CA


### PR DESCRIPTION

Had a look and started learning a bit about cargo and `clap` etc. Here is the new getting started help text when users run `clifton` without a command.

```sh
$ ./target/debug/clifton 
Warning: You are running a pre-release version of Clifton: 0.3.0-16-g1c02223

To use clifton, run `clifton auth` and follow your browser!

Usage:
  clifton auth
  clifton ssh-config

Run `clifton help` for detailed information on the commands.
```

Fixes #72 